### PR TITLE
fix: analytics-trigger must query closed issues with Published label

### DIFF
--- a/defaults/SOUL.md
+++ b/defaults/SOUL.md
@@ -1,6 +1,6 @@
-# SOUL.md - DevClaw Orchestrator Identity
+# SOUL.md - MarketClaw Orchestrator Identity
 
-You are a **development orchestrator** — you plan, prioritize, and dispatch. You never write code yourself.
+You are a **marketing orchestrator** — you plan, prioritize, and dispatch. You never write content yourself.
 
 ## Core Principles
 
@@ -10,13 +10,13 @@ You are a **development orchestrator** — you plan, prioritize, and dispatch. Y
 
 **Be transparent.** Include the announcement from tool responses verbatim — it has the links. Always explain what happened and what's next. No black boxes.
 
-**Be resourceful.** Check status before asking. Read the issue before dispatching. Understand the codebase before planning. Come back with answers, not questions.
+**Be resourceful.** Check status before asking. Read the brief before dispatching. Understand the campaign before planning. Come back with answers, not questions.
 
 ## How You Work
 
-- You receive requests via chat (Telegram, WhatsApp, or web)
-- You break work into issues, assign complexity levels, and dispatch workers
-- Workers (developer, reviewer, tester, architect) do the actual work in isolated sessions
+- You receive campaign requests via chat (Telegram, WhatsApp, or web)
+- You break campaigns into issues, assign complexity levels, and dispatch workers
+- Workers (strategist, creator, reviewer, publisher, analyst) do the actual work in isolated sessions
 - You track progress, handle failures, and keep the human informed
 - The heartbeat runs automatically — you don't manage it
 
@@ -29,10 +29,10 @@ You are a **development orchestrator** — you plan, prioritize, and dispatch. Y
 
 ## Boundaries
 
-- **Never write code** — dispatch a developer worker
-- **Code goes through review** before merging — enable the test phase in workflow.yaml for automated QA
+- **Never write content** — dispatch a creator worker
+- **Content goes through review** before publishing — the reviewer ensures brand consistency
 - **Don't close issues manually** — let the workflow handle it
-- **Ask before** architectural decisions affecting multiple projects
+- **Ask before** campaign decisions affecting strategy or brand
 
 ## Continuity
 

--- a/defaults/TOOLS.md
+++ b/defaults/TOOLS.md
@@ -1,15 +1,23 @@
-# TOOLS.md - DevClaw Tools
+# TOOLS.md - MarketClaw Tools
 
-All DevClaw tools are registered as OpenClaw plugin tools. Use the tool schemas for parameter details.
+All MarketClaw tools are registered as OpenClaw plugin tools. Use the tool schemas for parameter details.
 
 ## Config management
 
-DevClaw config files (workflow.yaml, prompts) are **write-once**: created on first setup, never overwritten on restart. Your customizations are always preserved.
+MarketClaw config files (workflow.yaml, prompts) are **write-once**: created on first setup, never overwritten on restart. Your customizations are always preserved.
 
-- `config_diff` — Compare your workflow.yaml against the built-in default. Shows what you've customized and what's new in updates.
-- `config_reset` — Reset config files to defaults (creates .bak backups). Supports `target`: "workflow", "prompts", or "all".
+- `config` (action: "diff") — Compare your workflow.yaml against the built-in default. Shows what you've customized and what's new in updates.
+- `config` (action: "reset") — Reset config files to defaults (creates .bak backups). Supports `scope`: "workflow", "prompts", or "all".
 
 ## Project-specific overrides
 
 To override tool behavior for a specific project, create prompt files in:
 `marketclaw/projects/<name>/prompts/<role>.md`
+
+## Content calendar
+
+- `task_schedule` — Set or clear the Publish Date on a content issue. The heartbeat dispatches the Publisher worker automatically when the date arrives.
+
+## Analytics
+
+Set `analyzeAfterDays` in `marketclaw/workflow.yaml` to control how many days after publication the Analyst worker is triggered. Default: 7.

--- a/defaults/TOOLS.md
+++ b/defaults/TOOLS.md
@@ -12,4 +12,4 @@ DevClaw config files (workflow.yaml, prompts) are **write-once**: created on fir
 ## Project-specific overrides
 
 To override tool behavior for a specific project, create prompt files in:
-`devclaw/projects/<name>/prompts/<role>.md`
+`marketclaw/projects/<name>/prompts/<role>.md`

--- a/lib/config/loader.ts
+++ b/lib/config/loader.ts
@@ -3,8 +3,8 @@
  *
  * Resolution order:
  *   1. Built-in defaults (ROLE_REGISTRY + DEFAULT_WORKFLOW)
- *   2. Workspace: <workspace>/devclaw/workflow.yaml
- *   3. Project:   <workspace>/devclaw/projects/<project>/workflow.yaml
+ *   2. Workspace: <workspace>/marketclaw/workflow.yaml
+ *   3. Project:   <workspace>/marketclaw/projects/<project>/workflow.yaml
  *
  * Also supports legacy config.yaml and workflow.json for backward compat.
  */
@@ -33,7 +33,7 @@ export async function loadConfig(
   // Layer 1: built-in defaults
   const builtIn = buildDefaultConfig();
 
-  // Layer 2: workspace workflow.yaml (in devclaw/ data dir)
+  // Layer 2: workspace workflow.yaml (in marketclaw/ data dir)
   let merged = builtIn;
   const workspaceConfig =
     await readWorkflowFile(dataDir) ??

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,5 +1,5 @@
 /**
- * context.ts — Lightweight DI container for the DevClaw plugin.
+ * context.ts — Lightweight DI container for the MarketClaw plugin.
  *
  * Created once in register() and threaded to all tools, services, and hooks.
  * Replaces the global singleton in run-command.ts with explicit injection.
@@ -13,7 +13,7 @@ import type { OpenClawPluginApi, PluginRuntime } from "openclaw/plugin-sdk";
 export type RunCommand = OpenClawPluginApi["runtime"]["system"]["runCommandWithTimeout"];
 
 /**
- * PluginContext — shared services for all DevClaw modules.
+ * PluginContext — shared services for all MarketClaw modules.
  *
  * No framework, no decorators — just a plain object created once and
  * passed through factory functions and service registrations.

--- a/lib/dispatch/attachment-hook.ts
+++ b/lib/dispatch/attachment-hook.ts
@@ -51,14 +51,14 @@ async function resolveProjectFromChannel(
 
 /**
  * Resolve the workspace directory from OpenClaw config.
- * Checks agents.defaults.workspace, then falls back to ~/.openclaw/workspace-devclaw.
+ * Checks agents.defaults.workspace, then falls back to ~/.openclaw/workspace-marketclaw.
  */
 function resolveWorkspaceDir(config: Record<string, unknown>): string | null {
   const agents = config.agents as { defaults?: { workspace?: string }; list?: Array<{ id: string; workspace?: string }> } | undefined;
   if (agents?.defaults?.workspace) return agents.defaults.workspace;
-  const devclaw = agents?.list?.find((a) => a.id === "devclaw");
-  if (devclaw?.workspace) return devclaw.workspace;
-  return path.join(homedir(), ".openclaw", "workspace-devclaw");
+  const marketclaw = agents?.list?.find((a) => a.id === "marketclaw");
+  if (marketclaw?.workspace) return marketclaw.workspace;
+  return path.join(homedir(), ".openclaw", "workspace-marketclaw");
 }
 
 /**

--- a/lib/dispatch/attachments.ts
+++ b/lib/dispatch/attachments.ts
@@ -9,8 +9,8 @@
  *   5. Attachments are available for architects/developers in task context
  *
  * Storage layout:
- *   devclaw/attachments/<projectSlug>/<issueId>/<uuid>-<filename>
- *   devclaw/attachments/<projectSlug>/<issueId>/metadata.json
+ *   marketclaw/attachments/<projectSlug>/<issueId>/<uuid>-<filename>
+ *   marketclaw/attachments/<projectSlug>/<issueId>/metadata.json
  */
 import fs from "node:fs/promises";
 import path from "node:path";

--- a/lib/dispatch/bootstrap-hook.ts
+++ b/lib/dispatch/bootstrap-hook.ts
@@ -24,9 +24,9 @@ import { DEFAULT_ROLE_INSTRUCTIONS } from "../setup/templates.js";
  * Session key format (numeric): `agent:{agentId}:subagent:{projectName}-{role}-{level}-{slotIndex}`
  * Session key format (legacy): `agent:{agentId}:subagent:{projectName}-{role}-{level}`
  * Examples:
- *   - `agent:devclaw:subagent:my-project-developer-medior-ada`  → { projectName: "my-project", role: "developer" }
- *   - `agent:devclaw:subagent:my-project-developer-medior-0`    → { projectName: "my-project", role: "developer" }
- *   - `agent:devclaw:subagent:webapp-tester-medior`              → { projectName: "webapp", role: "tester" } (legacy)
+ *   - `agent:marketclaw:subagent:my-project-developer-medior-ada`  → { projectName: "my-project", role: "developer" }
+ *   - `agent:marketclaw:subagent:my-project-developer-medior-0`    → { projectName: "my-project", role: "developer" }
+ *   - `agent:marketclaw:subagent:webapp-tester-medior`              → { projectName: "webapp", role: "tester" } (legacy)
  *
  * Note: projectName may contain hyphens, so we match role from the end.
  */
@@ -62,9 +62,9 @@ export type RoleInstructionsResult = {
  * Returns both the content and the source path for logging/traceability.
  *
  * Resolution order:
- *   1. devclaw/projects/<project>/prompts/<role>.md  (project-specific override)
+ *   1. marketclaw/projects/<project>/prompts/<role>.md  (project-specific override)
  *   2. projects/roles/<project>/<role>.md             (old project-specific)
- *   3. devclaw/prompts/<role>.md                      (workspace default)
+ *   3. marketclaw/prompts/<role>.md                      (workspace default)
  *   4. projects/roles/default/<role>.md               (old default)
  *   5. Package default from templates.ts              (in-memory fallback)
  */
@@ -187,7 +187,7 @@ export function registerBootstrapHook(api: OpenClawPluginApi, ctx: PluginContext
       }
     },
     {
-      name: "devclaw-bootstrap-role-instructions",
+      name: "marketclaw-bootstrap-role-instructions",
       description:
         "Replaces orchestrator AGENTS.md with role-specific instructions for DevClaw workers",
     } as any,

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -88,8 +88,8 @@ export function sendToAgent(
 ): void {
   const rc = opts.runCommand;
   const gatewayParams = JSON.stringify({
-    idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${opts.fromLabel ?? "unknown"}-${sessionKey}`,
-    agentId: opts.agentId ?? "devclaw",
+    idempotencyKey: `marketclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${opts.fromLabel ?? "unknown"}-${sessionKey}`,
+    agentId: opts.agentId ?? "marketclaw",
     sessionKey,
     message: taskMessage,
     deliver: false,

--- a/lib/instance.ts
+++ b/lib/instance.ts
@@ -2,7 +2,7 @@
  * instance.ts — Persistent instance identity.
  *
  * Each workspace gets a unique fun name (CS pioneer) stored in
- * <workspace>/devclaw/instance.json. The name is generated on first
+ * <workspace>/marketclaw/instance.json. The name is generated on first
  * access and persisted across restarts.
  *
  * Can be overridden via `instance.name` in workflow.yaml.

--- a/lib/projects/schema-migration.ts
+++ b/lib/projects/schema-migration.ts
@@ -56,8 +56,8 @@ export async function getRepoRemote(repoPath: string, runCommand?: RunCommand): 
  * and merges worker state (taking the most recent active worker).
  *
  * Example:
- *   Input: { "-5176490302": { name: "devclaw", ... }, "-1003843401024": { name: "devclaw", ... } }
- *   Output: { "devclaw": { slug: "devclaw", channels: [...], ... } }
+ *   Input: { "-5176490302": { name: "marketclaw", ... }, "-1003843401024": { name: "marketclaw", ... } }
+ *   Output: { "marketclaw": { slug: "marketclaw", channels: [...], ... } }
  */
 export async function migrateLegacySchema(data: any, runCommand?: RunCommand): Promise<ProjectsData> {
   const legacyProjects = data.projects as Record<string, LegacyProject>;

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -667,7 +667,7 @@ export class GitHubProvider implements IssueProvider {
     file: { filename: string; buffer: Buffer; mimeType: string },
   ): Promise<string | null> {
     try {
-      const branch = "devclaw-attachments";
+      const branch = "marketclaw-attachments";
       const safeFilename = file.filename.replace(/[^a-zA-Z0-9._-]/g, "_");
       const filePath = `attachments/${issueId}/${Date.now()}-${safeFilename}`;
       const base64Content = file.buffer.toString("base64");

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -207,9 +207,10 @@ export class GitHubProvider implements IssueProvider {
     return this.getIssue(parseInt(match[1], 10));
   }
 
-  async listIssuesByLabel(label: StateLabel): Promise<Issue[]> {
+  async listIssuesByLabel(label: StateLabel, opts?: { state?: "open" | "closed" | "all" }): Promise<Issue[]> {
     try {
-      const raw = await this.gh(["issue", "list", "--label", label, "--state", "open", "--json", "number,title,body,labels,state,url"]);
+      const state = opts?.state ?? "open";
+      const raw = await this.gh(["issue", "list", "--label", label, "--state", state, "--json", "number,title,body,labels,state,url"]);
       return (JSON.parse(raw) as GhIssue[]).map(toIssue);
     } catch { return []; }
   }

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -97,9 +97,14 @@ export class GitLabProvider implements IssueProvider {
     return this.getIssue(parseInt(match[1], 10));
   }
 
-  async listIssuesByLabel(label: StateLabel): Promise<Issue[]> {
+  async listIssuesByLabel(label: StateLabel, opts?: { state?: "open" | "closed" | "all" }): Promise<Issue[]> {
     try {
-      const raw = await this.glab(["issue", "list", "--label", label, "--output", "json"]);
+      const args = ["issue", "list", "--label", label, "--output", "json"];
+      const state = opts?.state ?? "open";
+      if (state === "closed") args.push("--closed");
+      else if (state === "all") args.push("--all");
+      else args.push("--opened");
+      const raw = await this.glab(args);
       return JSON.parse(raw) as Issue[];
     } catch { return []; }
   }

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -543,7 +543,7 @@ export class GitLabProvider implements IssueProvider {
       const os = await import("node:os");
       const fs = await import("node:fs/promises");
       const path = await import("node:path");
-      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-upload-"));
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "marketclaw-upload-"));
       const tmpFile = path.join(tmpDir, file.filename);
       await fs.writeFile(tmpFile, file.buffer);
 

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -160,7 +160,7 @@ export interface IssueProvider {
    * Upload a file attachment and return a public URL for embedding in issues.
    * Returns null if the provider doesn't support uploads or the upload fails.
    *
-   * GitHub: commits file to a `devclaw-attachments` branch, returns raw URL.
+   * GitHub: commits file to a `marketclaw-attachments` branch, returns raw URL.
    * GitLab: uses the native project uploads API.
    */
   uploadAttachment(issueId: number, file: {

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -74,7 +74,7 @@ export interface IssueProvider {
   ensureLabel(name: string, color: string): Promise<void>;
   ensureAllStateLabels(): Promise<void>;
   createIssue(title: string, description: string, label: StateLabel, assignees?: string[]): Promise<Issue>;
-  listIssuesByLabel(label: StateLabel): Promise<Issue[]>;
+  listIssuesByLabel(label: StateLabel, opts?: { state?: "open" | "closed" | "all" }): Promise<Issue[]>;
   /** List issues with optional filters. Provider-agnostic — future Jira/Linear/Trello can map to native queries. */
   listIssues(opts?: { label?: string; state?: "open" | "closed" | "all" }): Promise<Issue[]>;
   getIssue(issueId: number): Promise<Issue>;

--- a/lib/roles/index.ts
+++ b/lib/roles/index.ts
@@ -1,7 +1,7 @@
 /**
  * roles/ — Centralized role configuration.
  *
- * Single source of truth for all worker roles in DevClaw.
+ * Single source of truth for all worker roles in MarketClaw.
  * To add a new role, add an entry to registry.ts — everything else derives from it.
  */
 export { ROLE_REGISTRY } from "./registry.js";

--- a/lib/roles/llm-model-selector.ts
+++ b/lib/roles/llm-model-selector.ts
@@ -1,7 +1,7 @@
 /**
  * llm-model-selector.ts — LLM-powered intelligent model selection.
  *
- * Uses an LLM to understand model capabilities and assign optimal models to DevClaw roles.
+ * Uses an LLM to understand model capabilities and assign optimal models to MarketClaw roles.
  */
 import type { RunCommand } from "../context.js";
 import { ROLE_REGISTRY } from "./index.js";
@@ -66,7 +66,7 @@ function validateAssignment(
 }
 
 /**
- * Use an LLM to intelligently select and assign models to DevClaw roles.
+ * Use an LLM to intelligently select and assign models to MarketClaw roles.
  */
 export async function selectModelsWithLLM(
   availableModels: Array<{ model: string; provider: string }>,
@@ -86,7 +86,7 @@ export async function selectModelsWithLLM(
   const modelList = availableModels.map((m) => m.model).join("\n");
   const jsonExample = buildJsonExample();
 
-  const prompt = `You are an AI model expert. Analyze the following authenticated AI models and assign them to DevClaw development roles based on their capabilities.
+  const prompt = `You are an AI model expert. Analyze the following authenticated AI models and assign them to MarketClaw marketing roles based on their capabilities.
 
 Available models:
 ${modelList}
@@ -108,7 +108,7 @@ Return ONLY a JSON object in this exact format (no markdown, no explanation):
 ${jsonExample}`;
 
   try {
-    const sessionId = "devclaw-model-selection";
+    const sessionId = "marketclaw-model-selection";
 
     if (!execCommand) {
       throw new Error("execCommand is required for LLM model selection");

--- a/lib/roles/model-selector.ts
+++ b/lib/roles/model-selector.ts
@@ -27,6 +27,12 @@ const SIMPLE_KEYWORDS = [
   "style",
   "copy",
   "wording",
+  // Marketing-specific simple keywords
+  "quick post",
+  "single tweet",
+  "short email",
+  "repost",
+  "caption",
 ];
 
 // Keywords that indicate complex tasks
@@ -41,6 +47,12 @@ const COMPLEX_KEYWORDS = [
   "performance",
   "infrastructure",
   "multi-service",
+  // Marketing-specific complex keywords
+  "strategy",
+  "campaign",
+  "competitor analysis",
+  "launch",
+  "brand positioning",
 ];
 
 /**

--- a/lib/roles/smart-model-selector.ts
+++ b/lib/roles/smart-model-selector.ts
@@ -1,7 +1,7 @@
 /**
- * smart-model-selector.ts — LLM-powered model selection for DevClaw roles.
+ * smart-model-selector.ts — LLM-powered model selection for MarketClaw roles.
  *
- * Uses an LLM to intelligently analyze and assign models to DevClaw roles.
+ * Uses an LLM to intelligently analyze and assign models to MarketClaw roles.
  */
 import { getAllRoleIds, getLevelsForRole } from "./index.js";
 import { ROLE_REGISTRY } from "./index.js";
@@ -25,7 +25,7 @@ function singleModelAssignment(model: string): ModelAssignment {
 }
 
 /**
- * Assign available models to DevClaw roles.
+ * Assign available models to MarketClaw roles.
  *
  * Strategy:
  * 1. If 0 models → return null (setup should be blocked)
@@ -105,7 +105,7 @@ export function formatAssignment(assignment: ModelAssignment): string {
  * Generate setup instructions when no models are available.
  */
 export function generateSetupInstructions(): string {
-  return `❌ No authenticated models found. DevClaw needs at least one model to work.
+  return `❌ No authenticated models found. MarketClaw needs at least one model to work.
 
 To configure model authentication:
 

--- a/lib/services/heartbeat/analytics-trigger.ts
+++ b/lib/services/heartbeat/analytics-trigger.ts
@@ -102,8 +102,8 @@ export async function analyticsTriggerPass(opts: {
     // Target must be an analyst queue
     if (targetState.role !== "analyst" || targetState.type !== StateType.QUEUE) continue;
 
-    // Fetch issues in this "published" state
-    const issues = await provider.listIssuesByLabel(state.label);
+    // Fetch issues in this "published" state — closed because publisher closes the issue on completion
+    const issues = await provider.listIssuesByLabel(state.label, { state: "closed" });
     const now = new Date();
     const thresholdMs = analyzeAfterDays * 24 * 60 * 60 * 1000;
 

--- a/lib/services/heartbeat/index.ts
+++ b/lib/services/heartbeat/index.ts
@@ -48,7 +48,7 @@ export function registerHeartbeatService(api: OpenClawPluginApi, pluginCtx: Plug
   let intervalId: ReturnType<typeof setInterval> | null = null;
 
   api.registerService({
-    id: "devclaw-heartbeat",
+    id: "marketclaw-heartbeat",
 
     start: async (svcCtx: ServiceContext) => {
       const { intervalSeconds } = HEARTBEAT_DEFAULTS;

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -223,7 +223,7 @@ export async function executeCompletion(opts: {
   await deactivateWorker(workspaceDir, projectSlug, role, { level: opts.level, slotIndex: opts.slotIndex, issueId: String(issueId) });
 
   // Send review routing notification when developer completes
-  if (role === "developer" && result === "done") {
+  if ((role === "developer" || role === "creator") && result === "done") {
     // Re-fetch issue to get labels after transition
     const updated = await provider.getIssue(issueId);
     const routing = detectStepRouting(updated.labels, "review") as "human" | "agent" | null;

--- a/lib/setup/cli.ts
+++ b/lib/setup/cli.ts
@@ -24,16 +24,16 @@ function getDefaultWorkspaceDir(runtime: PluginRuntime): string | undefined {
 }
 
 /**
- * Register the `devclaw` CLI command group on a Commander program.
+ * Register the `marketclaw` CLI command group on a Commander program.
  */
 export function registerCli(program: Command, ctx: PluginContext): void {
-  const devclaw = program
+  const marketclaw = program
     .command("marketclaw")
-    .description("DevClaw development pipeline tools");
+    .description("MarketClaw AI marketing pipeline tools");
 
-  const setupCmd = devclaw
+  const setupCmd = marketclaw
     .command("setup")
-    .description("Set up DevClaw: create agent, configure models, write workspace files")
+    .description("Set up MarketClaw: create agent, configure models, write workspace files")
     .option("--new-agent <name>", "Create a new agent with this name")
     .option("--agent <id>", "Use an existing agent by ID")
     .option("--workspace <path>", "Direct workspace path");
@@ -99,7 +99,7 @@ export function registerCli(program: Command, ctx: PluginContext): void {
     });
 
   // Channel management commands
-  const channel = devclaw
+  const channel = marketclaw
     .command("channel")
     .description("Manage project channels (register, deregister, list)");
 

--- a/lib/setup/config.ts
+++ b/lib/setup/config.ts
@@ -9,11 +9,11 @@ import { HEARTBEAT_DEFAULTS } from "../services/heartbeat/index.js";
 import type { ExecutionMode } from "../workflow/index.js";
 
 /**
- * Write DevClaw plugin config to openclaw.json plugins section.
+ * Write MarketClaw plugin config to openclaw.json plugins section.
  *
  * Configures:
- * - Tool restrictions (deny sessions_spawn, sessions_send) for DevClaw agents
- * - Subagent cleanup interval (30 days) to keep development sessions alive
+ * - Tool restrictions (deny sessions_spawn, sessions_send) for MarketClaw agents
+ * - Subagent cleanup interval (30 days) to keep content sessions alive
  * - Heartbeat defaults
  *
  * Read-modify-write to preserve existing config.
@@ -29,11 +29,11 @@ export async function writePluginConfig(
   ensurePluginStructure(config);
 
   if (projectExecution) {
-    (config as any).plugins.entries.devclaw.config.projectExecution = projectExecution;
+    (config as any).plugins.entries.marketclaw.config.projectExecution = projectExecution;
   }
 
   // Clean up legacy models from openclaw.json (moved to workflow.yaml)
-  delete (config as any).plugins.entries.devclaw.config.models;
+  delete (config as any).plugins.entries.marketclaw.config.models;
 
   ensurePluginAllowed(config);
   ensureInternalHooks(config);
@@ -57,20 +57,20 @@ function ensurePluginStructure(config: Record<string, unknown>): void {
   const plugins = config.plugins as Record<string, unknown>;
   if (!plugins.entries) plugins.entries = {};
   const entries = plugins.entries as Record<string, unknown>;
-  if (!entries.devclaw) entries.devclaw = {};
-  const devclaw = entries.devclaw as Record<string, unknown>;
-  if (!devclaw.config) devclaw.config = {};
+  if (!entries.marketclaw) entries.marketclaw = {};
+  const marketclaw = entries.marketclaw as Record<string, unknown>;
+  if (!marketclaw.config) marketclaw.config = {};
 }
 
 /**
- * Ensure "devclaw" is in plugins.allow so OpenClaw trusts the plugin
+ * Ensure "marketclaw" is in plugins.allow so OpenClaw trusts the plugin
  * without requiring manual config after install.
  */
 function ensurePluginAllowed(config: Record<string, unknown>): void {
   const plugins = config.plugins as Record<string, unknown>;
   if (!Array.isArray(plugins.allow)) plugins.allow = [];
   const allow = plugins.allow as string[];
-  if (!allow.includes("devclaw")) allow.push("devclaw");
+  if (!allow.includes("marketclaw")) allow.push("marketclaw");
 }
 
 function configureSubagentCleanup(config: Record<string, unknown>): void {
@@ -99,9 +99,9 @@ function ensureInternalHooks(config: Record<string, unknown>): void {
 }
 
 function ensureHeartbeatDefaults(config: Record<string, unknown>): void {
-  const devclaw = (config as any).plugins.entries.devclaw.config;
-  if (!devclaw.work_heartbeat) {
-    devclaw.work_heartbeat = { ...HEARTBEAT_DEFAULTS };
+  const marketclaw = (config as any).plugins.entries.marketclaw.config;
+  if (!marketclaw.work_heartbeat) {
+    marketclaw.work_heartbeat = { ...HEARTBEAT_DEFAULTS };
   }
 }
 

--- a/lib/setup/index.ts
+++ b/lib/setup/index.ts
@@ -1,8 +1,8 @@
 /**
- * setup/index.ts — DevClaw setup orchestrator.
+ * setup/index.ts — MarketClaw setup orchestrator.
  *
  * Coordinates: agent creation → plugin config → workspace scaffolding → model config.
- * Used by both the `setup` tool and the `openclaw devclaw setup` CLI command.
+ * Used by both the `setup` tool and the `openclaw marketclaw setup` CLI command.
  */
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -54,7 +54,7 @@ export type SetupResult = {
 };
 
 /**
- * Run the full DevClaw setup.
+ * Run the full MarketClaw setup.
  *
  * 1. Create agent (optional) or resolve existing workspace
  * 2. Write plugin config to openclaw.json (heartbeat, tool restrictions — no models)

--- a/lib/setup/migrate-layout.ts
+++ b/lib/setup/migrate-layout.ts
@@ -1,25 +1,25 @@
 /**
  * setup/migrate-layout.ts — One-time workspace layout migration.
  *
- * Migrates from old layouts to the current devclaw/ data directory:
+ * Migrates from old layouts to the current marketclaw/ data directory:
  *
- * Very old layout (pre-restructure):
- *   projects/projects.json          → devclaw/projects.json
- *   projects/config.yaml            → devclaw/workflow.yaml
- *   projects/roles/default/*        → devclaw/prompts/* (with dev.md→developer.md, qa.md→tester.md)
- *   projects/roles/<project>/*      → devclaw/projects/<project>/prompts/*
- *   projects/<project>/config.yaml  → devclaw/projects/<project>/workflow.yaml
+ * Very old layout (pre-restructure, DevClaw-era):
+ *   projects/projects.json          → marketclaw/projects.json
+ *   projects/config.yaml            → marketclaw/workflow.yaml
+ *   projects/roles/default/*        → marketclaw/prompts/*
+ *   projects/roles/<project>/*      → marketclaw/projects/<project>/prompts/*
+ *   projects/<project>/config.yaml  → marketclaw/projects/<project>/workflow.yaml
  *
- * Intermediate layout (post-restructure, pre-devclaw/):
- *   projects.json                   → devclaw/projects.json
- *   workflow.yaml                   → devclaw/workflow.yaml
- *   prompts/*                       → devclaw/prompts/*
- *   projects/<project>/*.md         → devclaw/projects/<project>/prompts/*
- *   projects/<project>/workflow.yaml→ devclaw/projects/<project>/workflow.yaml
- *   log/*                           → devclaw/log/*
+ * Intermediate layout (post-restructure, pre-marketclaw/):
+ *   projects.json                   → marketclaw/projects.json
+ *   workflow.yaml                   → marketclaw/workflow.yaml
+ *   prompts/*                       → marketclaw/prompts/*
+ *   projects/<project>/*.md         → marketclaw/projects/<project>/prompts/*
+ *   projects/<project>/workflow.yaml→ marketclaw/projects/<project>/workflow.yaml
+ *   log/*                           → marketclaw/log/*
  *
- * Flat project layout (early devclaw/ without prompts subdir):
- *   devclaw/projects/<project>/*.md → devclaw/projects/<project>/prompts/*
+ * Flat project layout (early marketclaw/ without prompts subdir):
+ *   marketclaw/projects/<project>/*.md → marketclaw/projects/<project>/prompts/*
  *
  * This file can be removed once all workspaces have been migrated.
  */
@@ -52,12 +52,12 @@ export async function ensureWorkspaceMigrated(workspaceDir: string): Promise<voi
 }
 
 /**
- * Migrate workspace from old layouts to new devclaw/ data directory.
+ * Migrate workspace from old layouts to new marketclaw/ data directory.
  *
  * Detects four states:
- * 1. Already migrated: devclaw/projects.json exists → check prompt subdir migration
- * 2. Intermediate layout: projects.json at workspace root → move into devclaw/
- * 3. Very old layout: projects/projects.json → full migration into devclaw/
+ * 1. Already migrated: marketclaw/projects.json exists → check prompt subdir migration
+ * 2. Intermediate layout: projects.json at workspace root → move into marketclaw/
+ * 3. Very old layout: projects/projects.json → full migration into marketclaw/
  * 4. Empty workspace → no-op
  */
 export async function migrateWorkspaceLayout(workspaceDir: string): Promise<void> {
@@ -70,7 +70,7 @@ export async function migrateWorkspaceLayout(workspaceDir: string): Promise<void
     return;
   }
 
-  // Check for intermediate layout (post-restructure, pre-devclaw/)
+  // Check for intermediate layout (post-restructure, pre-marketclaw/)
   const rootProjectsJson = path.join(workspaceDir, "projects.json");
   if (await fileExists(rootProjectsJson)) {
     await migrateFromIntermediate(workspaceDir, dataDir);
@@ -87,7 +87,7 @@ export async function migrateWorkspaceLayout(workspaceDir: string): Promise<void
 
 /**
  * Move flat prompt files in project dirs into prompts/ subdirs.
- * Handles: devclaw/projects/<project>/<role>.md → devclaw/projects/<project>/prompts/<role>.md
+ * Handles: marketclaw/projects/<project>/<role>.md → marketclaw/projects/<project>/prompts/<role>.md
  */
 async function migratePromptSubdirs(dataDir: string): Promise<void> {
   const projectsDir = path.join(dataDir, "projects");
@@ -121,7 +121,7 @@ async function migratePromptSubdirs(dataDir: string): Promise<void> {
 }
 
 /**
- * Migrate from intermediate layout (files at workspace root) into devclaw/.
+ * Migrate from intermediate layout (files at workspace root) into marketclaw/.
  */
 async function migrateFromIntermediate(workspaceDir: string, dataDir: string): Promise<void> {
   await fs.mkdir(dataDir, { recursive: true });
@@ -158,17 +158,17 @@ async function migrateFromIntermediate(workspaceDir: string, dataDir: string): P
 }
 
 /**
- * Migrate from very old layout (projects/projects.json) directly into devclaw/.
+ * Migrate from very old layout (projects/projects.json) directly into marketclaw/.
  */
 async function migrateFromOldLayout(workspaceDir: string, dataDir: string): Promise<void> {
   await fs.mkdir(dataDir, { recursive: true });
 
-  // 1. Move projects/projects.json → devclaw/projects.json
+  // 1. Move projects/projects.json → marketclaw/projects.json
   const oldProjectsJson = path.join(workspaceDir, "projects", "projects.json");
   await safeCopy(oldProjectsJson, path.join(dataDir, "projects.json"));
   await fs.unlink(oldProjectsJson);
 
-  // 2. Move projects/config.yaml → devclaw/workflow.yaml
+  // 2. Move projects/config.yaml → marketclaw/workflow.yaml
   const oldConfig = path.join(workspaceDir, "projects", "config.yaml");
   const newConfig = path.join(dataDir, "workflow.yaml");
   if (await fileExists(oldConfig) && !await fileExists(newConfig)) {
@@ -176,7 +176,7 @@ async function migrateFromOldLayout(workspaceDir: string, dataDir: string): Prom
     await fs.unlink(oldConfig);
   }
 
-  // 3. Move projects/roles/default/* → devclaw/prompts/* (with renames)
+  // 3. Move projects/roles/default/* → marketclaw/prompts/* (with renames)
   const oldDefaultsDir = path.join(workspaceDir, "projects", "roles", "default");
   const newPromptsDir = path.join(dataDir, "prompts");
   if (await dirExists(oldDefaultsDir)) {
@@ -193,7 +193,7 @@ async function migrateFromOldLayout(workspaceDir: string, dataDir: string): Prom
     await rmEmptyDir(oldDefaultsDir);
   }
 
-  // 4. Move projects/roles/<project>/* → devclaw/projects/<project>/prompts/* (with renames)
+  // 4. Move projects/roles/<project>/* → marketclaw/projects/<project>/prompts/* (with renames)
   const oldRolesDir = path.join(workspaceDir, "projects", "roles");
   if (await dirExists(oldRolesDir)) {
     const entries = await fs.readdir(oldRolesDir, { withFileTypes: true });
@@ -218,7 +218,7 @@ async function migrateFromOldLayout(workspaceDir: string, dataDir: string): Prom
     await rmEmptyDir(oldRolesDir);
   }
 
-  // 5. Rename projects/<project>/config.yaml → devclaw/projects/<project>/workflow.yaml
+  // 5. Rename projects/<project>/config.yaml → marketclaw/projects/<project>/workflow.yaml
   const oldProjectsDir = path.join(workspaceDir, "projects");
   if (await dirExists(oldProjectsDir)) {
     const entries = await fs.readdir(oldProjectsDir, { withFileTypes: true });

--- a/lib/setup/onboarding.ts
+++ b/lib/setup/onboarding.ts
@@ -14,7 +14,7 @@ import { getAllDefaultModels } from "../roles/index.js";
 export function isPluginConfigured(
   pluginConfig?: Record<string, unknown>,
 ): boolean {
-  // Models moved to workflow.yaml — check for any devclaw plugin config (heartbeat, notifications, etc.)
+  // Models moved to workflow.yaml — check for any marketclaw plugin config (heartbeat, notifications, etc.)
   return !!pluginConfig && Object.keys(pluginConfig).length > 0;
 }
 
@@ -100,7 +100,7 @@ MarketClaw turns each Telegram group into an autonomous AI marketing team:
 ## Setup Steps
 
 **Step 1: Agent Selection**
-Ask: "Do you want to configure DevClaw for the current agent, or create a new dedicated agent?"
+Ask: "Do you want to configure MarketClaw for the current agent, or create a new dedicated agent?"
 - Current agent → no \`newAgentName\` needed
 - New agent → ask for:
   1. Agent name
@@ -116,7 +116,7 @@ Ask: "Do you want to configure DevClaw for the current agent, or create a new de
 
 1. **Call \`autoconfigure_models\`** to automatically discover and assign models:
    - Discovers all authenticated models in OpenClaw
-   - Uses AI to intelligently assign them to DevClaw roles
+   - Uses AI to intelligently assign them to MarketClaw roles
    - Returns a ready-to-use model configuration
 
 2. **Handle the result**:

--- a/lib/setup/version.ts
+++ b/lib/setup/version.ts
@@ -1,7 +1,7 @@
 /**
- * setup/version.ts — Version tracking for DevClaw workspaces.
+ * setup/version.ts — Version tracking for MarketClaw workspaces.
  *
- * Reads/writes `devclaw/.version` to track which version scaffolded the workspace.
+ * Reads/writes `marketclaw/.version` to track which version scaffolded the workspace.
  * Used for upgrade detection and audit logging.
  */
 import fsAsync from "node:fs/promises";
@@ -18,7 +18,7 @@ const VERSION_FILE = ".version";
 const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * Get the current DevClaw version.
+ * Get the current MarketClaw version.
  */
 export function getCurrentVersion(): string {
   if (typeof __PLUGIN_VERSION__ !== "undefined" && __PLUGIN_VERSION__) {
@@ -35,7 +35,7 @@ export function getCurrentVersion(): string {
 }
 
 /**
- * Read the stored version from `devclaw/.version`.
+ * Read the stored version from `marketclaw/.version`.
  * Returns null if the file doesn't exist (pre-versioning workspace).
  */
 export async function readVersionFile(dataDir: string): Promise<string | null> {
@@ -48,7 +48,7 @@ export async function readVersionFile(dataDir: string): Promise<string | null> {
 }
 
 /**
- * Write the current version to `devclaw/.version`.
+ * Write the current version to `marketclaw/.version`.
  */
 export async function writeVersionFile(dataDir: string): Promise<void> {
   await fsAsync.writeFile(

--- a/lib/setup/workspace.ts
+++ b/lib/setup/workspace.ts
@@ -65,15 +65,15 @@ export async function ensureDefaultFiles(workspacePath: string): Promise<void> {
   // Remove BOOTSTRAP.md — one-time onboarding file, not needed after setup
   try { await fs.unlink(path.join(workspacePath, "BOOTSTRAP.md")); } catch { /* already gone */ }
 
-  // devclaw/workflow.yaml — create-only (three-layer merge handles defaults for missing keys)
+  // marketclaw/workflow.yaml — create-only (three-layer merge handles defaults for missing keys)
   const workflowPath = path.join(dataDir, "workflow.yaml");
   await writeIfMissing(workflowPath, WORKFLOW_YAML_TEMPLATE);
 
-  // devclaw/projects.json — create-only
+  // marketclaw/projects.json — create-only
   const projectsJsonPath = path.join(dataDir, "projects.json");
   await writeIfMissing(projectsJsonPath, JSON.stringify({ projects: {} }, null, 2) + "\n");
 
-  // devclaw/prompts/ — create-only per role (user customizations are preserved)
+  // marketclaw/prompts/ — create-only per role (user customizations are preserved)
   for (const role of getAllRoleIds()) {
     const rolePath = path.join(dataDir, "prompts", `${role}.md`);
     const content = DEFAULT_ROLE_INSTRUCTIONS[role];
@@ -150,7 +150,7 @@ export async function writeAllDefaults(workspacePath: string, force = false): Pr
 }
 
 /**
- * Write all workspace files for a DevClaw agent.
+ * Write all workspace files for a MarketClaw agent.
  * Returns the list of files that were written (skips files that already exist).
  *
  * @param defaultWorkspacePath — If provided, USER.md is copied from here (only if not already present).

--- a/lib/testing/harness.ts
+++ b/lib/testing/harness.ts
@@ -168,7 +168,7 @@ export type TestHarness = {
   writePrompt(role: string, content: string, projectName?: string): Promise<void>;
   /**
    * Simulate the agent:bootstrap hook firing for a session key.
-   * Tests that AGENTS.md is stripped from bootstrap files for DevClaw workers.
+   * Tests that AGENTS.md is stripped from bootstrap files for MarketClaw workers.
    */
   simulateBootstrap(sessionKey: string): Promise<BootstrapResult>;
   /** Clean up temp directory. */
@@ -204,8 +204,8 @@ export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarn
   } = opts ?? {};
 
   // Create temp workspace
-  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-e2e-"));
-  const dataDir = path.join(workspaceDir, "devclaw");
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "marketclaw-e2e-"));
+  const dataDir = path.join(workspaceDir, "marketclaw");
   const logDir = path.join(dataDir, "log");
   await fs.mkdir(logDir, { recursive: true });
 

--- a/lib/testing/index.ts
+++ b/lib/testing/index.ts
@@ -1,5 +1,5 @@
 /**
- * testing/ — Test infrastructure for DevClaw integration tests.
+ * testing/ — Test infrastructure for MarketClaw integration tests.
  *
  * Exports:
  * - TestProvider: In-memory IssueProvider with call tracking

--- a/lib/tools/admin/autoconfigure-models.ts
+++ b/lib/tools/admin/autoconfigure-models.ts
@@ -44,7 +44,7 @@ export function createAutoConfigureModelsTool(ctx: PluginContext) {
     name: "autoconfigure_models",
     label: "Auto-Configure Models",
     description:
-      "Automatically discover authenticated models and intelligently assign them to DevClaw roles based on capability tiers",
+      "Automatically discover authenticated models and intelligently assign them to MarketClaw roles based on capability tiers",
     parameters: {
       type: "object",
       properties: {

--- a/lib/tools/admin/channel-link.ts
+++ b/lib/tools/admin/channel-link.ts
@@ -33,7 +33,7 @@ export function createChannelLinkTool(_ctx: PluginContext) {
         project: {
           type: "string",
           description:
-            "Project name or slug to link to (e.g. 'devclaw'). Must already be registered via project_register.",
+            "Project name or slug to link to (e.g. 'my-campaign-repo'). Must already be registered via project_register.",
         },
         channel: {
           type: "string",

--- a/lib/tools/admin/config-reset.ts
+++ b/lib/tools/admin/config-reset.ts
@@ -34,7 +34,7 @@ export function createConfigResetTool(_ctx: PluginContext) {
           type: "string",
           enum: ["workflow", "prompts", "all"],
           description:
-            "What to reset. 'workflow' = workflow.yaml, 'prompts' = devclaw/prompts/*.md, 'all' = both. Default: 'all'.",
+            "What to reset. 'workflow' = workflow.yaml, 'prompts' = marketclaw/prompts/*.md, 'all' = both. Default: 'all'.",
         },
       },
       required: ["channelId"],
@@ -48,7 +48,7 @@ export function createConfigResetTool(_ctx: PluginContext) {
       if (target === "workflow" || target === "all") {
         const workflowPath = path.join(dataDir, "workflow.yaml");
         await backupAndWrite(workflowPath, WORKFLOW_YAML_TEMPLATE);
-        resetFiles.push("devclaw/workflow.yaml");
+        resetFiles.push("marketclaw/workflow.yaml");
       }
 
       if (target === "prompts" || target === "all") {
@@ -59,7 +59,7 @@ export function createConfigResetTool(_ctx: PluginContext) {
           if (!content) continue;
           const rolePath = path.join(promptsDir, `${role}.md`);
           await backupAndWrite(rolePath, content);
-          resetFiles.push(`devclaw/prompts/${role}.md`);
+          resetFiles.push(`marketclaw/prompts/${role}.md`);
         }
       }
 

--- a/lib/tools/admin/config.ts
+++ b/lib/tools/admin/config.ts
@@ -83,14 +83,14 @@ async function handleReset(workspacePath: string, scope: string) {
   } else if (scope === "workflow") {
     const workflowPath = path.join(dataDir, "workflow.yaml");
     await backupAndWrite(workflowPath, WORKFLOW_YAML_TEMPLATE);
-    written.push("devclaw/workflow.yaml");
+    written.push("marketclaw/workflow.yaml");
   } else if (scope === "prompts") {
     const promptsDir = path.join(dataDir, "prompts");
     for (const [role, content] of Object.entries(DEFAULT_ROLE_INSTRUCTIONS)) {
       if (!content) continue;
       const rolePath = path.join(promptsDir, `${role}.md`);
       await backupAndWrite(rolePath, content);
-      written.push(`devclaw/prompts/${role}.md`);
+      written.push(`marketclaw/prompts/${role}.md`);
     }
   } else {
     throw new Error(`Unknown scope: ${scope}. Use: prompts, workflow, or all.`);

--- a/lib/tools/admin/setup.ts
+++ b/lib/tools/admin/setup.ts
@@ -1,5 +1,5 @@
 /**
- * setup — Agent-driven DevClaw setup.
+ * setup — Agent-driven MarketClaw setup.
  *
  * Creates agent, configures model levels, writes workspace files.
  * Thin wrapper around lib/setup/.
@@ -16,7 +16,7 @@ export function createSetupTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({
     name: "setup",
     label: "Setup",
-    description: `Execute DevClaw setup. Creates AGENTS.md, HEARTBEAT.md, TOOLS.md, devclaw/projects.json, devclaw/prompts/, and model level config. Optionally creates a new agent with channel binding. Called after onboard collects configuration.`,
+    description: `Execute MarketClaw setup. Creates AGENTS.md, HEARTBEAT.md, TOOLS.md, marketclaw/projects.json, marketclaw/prompts/, and model level config. Optionally creates a new agent with channel binding. Called after onboard collects configuration.`,
     parameters: {
       type: "object",
       properties: {

--- a/lib/tools/admin/workflow-guide.ts
+++ b/lib/tools/admin/workflow-guide.ts
@@ -98,13 +98,14 @@ Config is resolved by merging three layers (later layers override earlier):
 A project config only needs the keys it wants to override. Example project override:
 \`\`\`yaml
 roles:
-  developer:
+  creator:
     models:
       senior: anthropic/claude-opus-4-6
 workflow:
   reviewPolicy: agent
+  publishPolicy: human
 \`\`\`
-This changes only the senior developer model and review policy; everything else inherits.`;
+This changes only the senior creator model and review/publish policies; everything else inherits.`;
 }
 
 function buildStatesSection(): string {
@@ -124,7 +125,7 @@ function buildStatesSection(): string {
 | Field        | Type     | Required | Constrained? | Notes |
 |-------------|----------|----------|--------------|-------|
 | \`type\`      | string   | yes      | FIXED enum: \`queue\`, \`active\`, \`hold\`, \`terminal\` | |
-| \`role\`      | string   | for queue/active | Must match a role key from \`roles:\` section | e.g. \`developer\`, \`reviewer\`, \`tester\` |
+| \`role\`      | string   | for queue/active | Must match a role key from \`roles:\` section | e.g. \`creator\`, \`reviewer\`, \`publisher\`, \`analyst\`, \`strategist\` |
 | \`label\`     | string   | yes      | FREE — any text | Becomes a GitHub/GitLab label. Must be unique across states. |
 | \`color\`     | string   | yes      | FREE — any hex color | Format: \`"#rrggbb"\`. Used for the issue label color. |
 | \`priority\`  | number   | no       | FREE — any positive integer | Lower = higher priority. Only meaningful on \`queue\` states. |
@@ -291,7 +292,7 @@ Set in \`workflow.reviewPolicy\`:
 |---------|----------|
 | \`human\` | **(default)** All PRs wait for human approval on GitHub/GitLab. The heartbeat polls PR status and auto-merges when approved. |
 | \`agent\` | Every PR is reviewed by an agent (reviewer role) before merge. Agent can approve or reject. |
-| \`auto\`  | Hybrid: junior/medior developers → agent review, senior developers → human review. |
+| \`auto\`  | Hybrid: junior/medior creators → agent review, senior creators → human review. |
 
 ## How review routing works
 

--- a/lib/tools/admin/workflow-guide.ts
+++ b/lib/tools/admin/workflow-guide.ts
@@ -209,14 +209,15 @@ sync_labels channelId=-100123       # sync one project
 function buildRolesSection(): string {
   return `# Roles Configuration
 
-## Built-in roles (4 defaults — can override or disable)
+## Built-in MarketClaw roles (5 defaults — can override or disable)
 
-| Role       | Default levels          | Default level | Completion results         |
-|-----------|------------------------|---------------|----------------------------|
-| \`developer\`| junior, medior, senior | medior        | done, blocked              |
-| \`tester\`   | junior, medior, senior | medior        | pass, fail, refine, blocked|
-| \`architect\` | junior, senior         | junior        | done, blocked              |
-| \`reviewer\`  | junior, senior         | junior        | approve, reject, blocked   |
+| Role         | Default levels          | Default level | Completion results              |
+|-------------|------------------------|---------------|---------------------------------|
+| \`strategist\` | junior, senior         | junior        | done, blocked                   |
+| \`creator\`    | junior, medior, senior | medior        | done, blocked                   |
+| \`reviewer\`   | junior, senior         | junior        | approve, reject, blocked        |
+| \`publisher\`  | junior, senior         | junior        | pass, fail, blocked             |
+| \`analyst\`    | junior, senior         | junior        | done, blocked                   |
 
 ## Role config fields
 
@@ -237,15 +238,22 @@ function buildRolesSection(): string {
 | medior   | \`anthropic/claude-sonnet-4-5\`   |
 | senior   | \`anthropic/claude-opus-4-6\`     |
 
-Architect junior defaults to \`anthropic/claude-sonnet-4-5\`.
+Strategist junior defaults to \`anthropic/claude-sonnet-4-5\`.
 Reviewer senior defaults to \`anthropic/claude-sonnet-4-5\`.
+
+## MarketClaw-specific config fields
+
+| Field             | Type   | Default | Notes |
+|-------------------|--------|---------|-------|
+| \`publishPolicy\`  | string | \`agent\` | How publisher works: \`agent\` = dispatch publisher, \`skip\` = auto-transition to published, \`human\` = wait for manual trigger |
+| \`analyzeAfterDays\`| number | 7 | Days after publication before analytics is triggered. Set 0 to disable. |
 
 ## Disabling a role
 
 Set the role to \`false\`:
 \`\`\`yaml
 roles:
-  tester: false
+  analyst: false
 \`\`\`
 
 ## Adding a custom role
@@ -287,21 +295,29 @@ Set in \`workflow.reviewPolicy\`:
 
 ## How review routing works
 
-1. Developer finishes work → issue moves to \`toReview\` state
+1. Creator finishes content → issue moves to \`toReview\` state
 2. Heartbeat checks \`reviewPolicy\` to decide routing:
    - \`human\`: issue stays in \`toReview\`, heartbeat polls PR for approval
-   - \`agent\`: heartbeat dispatches a reviewer worker to check the PR
-   - \`auto\`: checks the developer level that worked on the issue
+   - \`agent\`: heartbeat dispatches a reviewer worker to check the content
+   - \`auto\`: checks the creator level that worked on the issue
 3. The \`toReview\` state should have a \`check: prApproved\` field for human review flow
+
+## How publish routing works
+
+1. Reviewer approves content → issue moves to \`toPublish\` state
+2. Heartbeat checks \`publishPolicy\` to decide routing:
+   - \`agent\` (default): heartbeat dispatches a publisher worker to post the content
+   - \`skip\`: auto-transition through publish queue without dispatching a worker
+   - \`human\`: wait for human to manually trigger publishing
 
 ## Per-issue override labels (FIXED format, applied to individual issues)
 
-| Label           | Effect |
-|----------------|--------|
-| \`review:human\` | Force human review for this issue regardless of policy |
-| \`review:agent\` | Force agent review for this issue |
-| \`review:skip\`  | Skip review entirely — go straight to done/test |
-| \`test:skip\`    | Skip the test phase for this issue (if testing enabled) |
+| Label            | Effect |
+|-----------------|--------|
+| \`review:human\`  | Force human review for this issue regardless of policy |
+| \`review:agent\`  | Force agent review for this issue |
+| \`review:skip\`   | Skip review entirely — go straight to publish queue |
+| \`publish:skip\`  | Skip publish phase — auto-transition to published state |
 
 These labels are applied to the issue on GitHub/GitLab and override the global policy.
 
@@ -316,85 +332,52 @@ The reviewer role must be configured (it is by default) and needs a prompt file 
 }
 
 function buildTestingSection(): string {
-  return `# Test Phase (Optional)
+  return `# Analytics Phase
 
-The test phase is **disabled by default**. When enabled, issues go through automated QA after review, before closing.
+The analytics phase is **enabled by default** with a 7-day delay after publication.
 
-## Default flow (no test phase)
+## Campaign pipeline
 \`\`\`
-Planning → To Do → Doing → To Review → [PR approved] → Done (auto-merge + close)
-\`\`\`
-
-## Flow with test phase enabled
-\`\`\`
-Planning → To Do → Doing → To Review → [PR approved] → To Test → Testing → Done
+Planning → To Research → Researching → [Done: creates content tasks]
+→ To Do → Creating → To Review → To Publish → Publishing → Published
+→ [7 days] → To Analyze → Analyzing → Done
 \`\`\`
 
-## How to enable the test phase
+## Analytics config
 
-Four changes needed:
+Control when analytics is triggered:
 
-### 1. Uncomment the toTest and testing states
-Add these states to your workflow (they're commented out in the default workflow.yaml):
 \`\`\`yaml
-    toTest:
-      type: queue
-      role: tester
-      label: To Test
-      color: "#5bc0de"
-      priority: 2
-      on:
-        PICKUP: testing
-    testing:
-      type: active
-      role: tester
-      label: Testing
-      color: "#9b59b6"
-      on:
-        PASS:
-          target: done
-          actions:
-            - closeIssue
-        FAIL:
-          target: toImprove
-          actions:
-            - reopenIssue
-        REFINE: refining
-        BLOCKED: refining
+workflow:
+  analyzeAfterDays: 7   # default: 7 days after publication
+  publishPolicy: agent  # how publisher is dispatched: agent | skip | human
 \`\`\`
 
-### 2. Change APPROVED targets from "done" to "toTest"
-In the \`toReview\` state:
+## Disabling analytics
+
+Set \`analyzeAfterDays\` to 0:
 \`\`\`yaml
-    toReview:
-      on:
-        APPROVED:
-          target: toTest        # was: done
-          actions:
-            - mergePr
-            - gitPull           # remove closeIssue — tester closes it
+workflow:
+  analyzeAfterDays: 0
 \`\`\`
 
-In the \`reviewing\` state (if using agent review):
-\`\`\`yaml
-    reviewing:
-      on:
-        APPROVE:
-          target: toTest        # was: done
-          actions:
-            - mergePr
-            - gitPull           # remove closeIssue — tester closes it
-\`\`\`
+## Publish policy options
 
-### 3. Remove closeIssue from the APPROVED/APPROVE actions
-The tester now closes the issue on PASS (via the testing state's PASS action).
-
-### 4. Create a tester prompt file
-Create \`<dataDir>/prompts/tester.md\` with instructions for the QA role.
-For project-specific: \`<dataDir>/projects/<name>/prompts/tester.md\`.
+| Value    | Behavior |
+|---------|----------|
+| \`agent\` | (default) Dispatch publisher worker to post content to platforms |
+| \`skip\`  | Auto-transition through publish queue without dispatching publisher |
+| \`human\` | Wait for human to manually trigger publishing |
 
 ## Per-issue skip
-Add the \`test:skip\` label to an issue to skip testing for that specific issue.`;
+Add the \`publish:skip\` label to an issue to skip automated publishing for that specific piece of content.
+
+## Strategist → Content task flow
+
+When a strategist completes research:
+1. Strategist creates individual content tasks in Planning (one per post/email/article)
+2. Operator reviews tasks in Planning and advances them to To Do when ready
+3. Each task flows independently through Creator → Reviewer → Publisher → Analyst`;
 }
 
 function buildTimeoutsSection(): string {
@@ -439,35 +422,35 @@ workflow:
   reviewPolicy: skip
 \`\`\`
 
-### Upgrade models for a critical project
+### Upgrade models for a high-priority campaign
 \`\`\`yaml
 roles:
-  developer:
+  creator:
     models:
       medior: anthropic/claude-opus-4-6
 \`\`\`
 
-### Disable tester for one project
+### Disable analytics for one project
 \`\`\`yaml
 roles:
-  tester: false
+  analyst: false
 \`\`\`
 
 ### Use different model provider
 \`\`\`yaml
 roles:
-  developer:
+  creator:
     models:
       junior: google/gemini-2.0-flash
       medior: google/gemini-2.5-pro
       senior: anthropic/claude-opus-4-6
 \`\`\`
 
-### Allow concurrent developers on a project
+### Allow concurrent creators on a project
 \`\`\`yaml
 roles:
-  developer:
-    maxWorkers: 3  # Allow up to 3 developers working in parallel
+  creator:
+    maxWorkers: 3  # Allow up to 3 creators working in parallel
 \`\`\`
 
 ### Override timeouts for a slow repo

--- a/lib/tools/tasks/research-task.ts
+++ b/lib/tools/tasks/research-task.ts
@@ -1,15 +1,15 @@
 /**
- * research_task — Start a research ticket in "To Research" state and dispatch the architect.
+ * research_task — Start a research ticket in "To Research" state and dispatch the strategist.
  *
- * The architect picks up the issue, researches, posts findings, and creates
- * implementation tasks via task_create. Then calls work_finish(result="done")
- * which closes the research issue (findings preserved in comments).
+ * The strategist picks up the issue, researches the market/competition/audience,
+ * writes a campaign brief, and creates content tasks via task_create.
+ * Then calls work_finish(result="done") which closes the research issue.
  *
  * Flow:
- *   research_task() → issue created in "To Research" → architect dispatched
- *   → architect researches, posts findings with task_comment
- *   → architect creates implementation tasks with task_create (land in Planning)
- *   → architect calls work_finish(result="done") → "Researching" → "Done" (issue closed)
+ *   research_task() → issue created in "To Research" → strategist dispatched
+ *   → strategist researches, writes brief, posts findings with task_comment
+ *   → strategist creates content tasks with task_create (land in Planning)
+ *   → strategist calls work_finish(result="done") → "Researching" → "Done" (issue closed)
  *   → operator reviews created tasks in Planning, moves to "To Do" when ready
  */
 import { jsonResult } from "openclaw/plugin-sdk";
@@ -32,24 +32,24 @@ export function createResearchTaskTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({
     name: "research_task",
     label: "Research Task",
-    description: `Spawn an architect to research a design/architecture problem. Creates a "To Research" issue and dispatches an architect worker.
+    description: `Spawn a strategist to research a marketing problem and write a campaign brief. Creates a "To Research" issue and dispatches a strategist worker.
 
-IMPORTANT: Provide a detailed description with enough background context for the architect
-to produce actionable, development-ready findings. Include: current state, constraints,
-requirements, relevant code paths, and any prior decisions. The output should be detailed
-enough for a developer to start implementation immediately.
+IMPORTANT: Provide a detailed description with enough background context for the strategist
+to produce actionable, campaign-ready findings. Include: target audience, business goals,
+constraints, competitor context, and any prior decisions. The output should be detailed
+enough for a creator to start writing content immediately.
 
-The architect will:
-1. Research the problem systematically (codebase, docs, web)
-2. Post findings as comments via task_comment
-3. Create implementation tasks via task_create (land in Planning for operator review)
+The strategist will:
+1. Research the market, audience, and competitors systematically
+2. Write a campaign brief with ICP, positioning, channels, KPIs, and content plan
+3. Create content tasks via task_create (land in Planning for operator review)
 4. Call work_finish(result="done", summary="<recommendation + task numbers>") — closes the research issue
 
 Example:
   research_task({
-    title: "Research: Session persistence strategy",
-    description: "Sessions are lost on restart. Current impl uses in-memory Map in session-store.ts. Constraints: must work with SQLite (already a dep), max 50ms latency on read. Prior discussion in #42 ruled out Redis.",
-    focusAreas: ["SQLite vs file-based", "migration path", "cache invalidation"],
+    title: "Research: mingles.ai LinkedIn presence launch",
+    description: "We want to establish a strong LinkedIn presence for mingles.ai. Target: AI-curious founders and product teams at 10-100 person companies. Goal: 500 followers and 3 warm leads in 60 days. No existing content strategy.",
+    focusAreas: ["ICP definition", "content angles", "posting cadence", "competitor analysis"],
     complexity: "complex"
   })`,
     parameters: {
@@ -62,21 +62,21 @@ Example:
         },
         title: {
           type: "string",
-          description: "Research title (e.g., 'Research: Session persistence strategy')",
+          description: "Research title (e.g., 'Research: mingles.ai LinkedIn launch campaign')",
         },
         description: {
           type: "string",
-          description: "Detailed background context: what exists today, why this needs investigation, constraints, relevant code paths, prior decisions. Must be detailed enough for the architect to produce development-ready findings.",
+          description: "Detailed background: target audience, business goals, constraints, competitor context, prior decisions. Must be detailed enough for the strategist to write a complete campaign brief.",
         },
         focusAreas: {
           type: "array",
           items: { type: "string" },
-          description: "Specific areas to investigate (e.g., ['performance', 'scalability', 'simplicity'])",
+          description: "Specific areas to investigate (e.g., ['ICP definition', 'content angles', 'posting cadence'])",
         },
         complexity: {
           type: "string",
           enum: ["simple", "medium", "complex"],
-          description: "Suggests architect level: simple/medium → junior, complex → senior. Defaults to medium.",
+          description: "Suggests strategist level: simple/medium → junior, complex → senior. Defaults to medium.",
         },
         dryRun: {
           type: "boolean",
@@ -95,14 +95,14 @@ Example:
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
       if (!title) throw new Error("title is required");
-      if (!description) throw new Error("description is required — provide detailed background context for the architect");
+      if (!description) throw new Error("description is required — provide detailed background context for the strategist");
 
       const { project } = await resolveProject(workspaceDir, channelId);
       const { provider } = await resolveProvider(project, ctx.runCommand);
       const pluginConfig = ctx.pluginConfig;
-      const role = "architect";
+      const role = "strategist";
 
-      // Build issue body with rich context for the architect to start from
+      // Build issue body with rich context for the strategist to start from
       const bodyParts = ["## Background", "", description];
       if (focusAreas.length > 0) {
         bodyParts.push("", "## Focus Areas", ...focusAreas.map((a) => `- ${a}`));
@@ -131,7 +131,7 @@ Example:
         });
       }
 
-      // Create issue in "To Research" (the architect queue state)
+      // Create issue in "To Research" (the strategist queue state)
       const issue = await provider.createIssue(title, issueBody, TO_RESEARCH_LABEL as StateLabel);
 
       // Mark as system-managed (best-effort).
@@ -146,8 +146,7 @@ Example:
       // Check worker availability across all levels
       const roleWorker = getRoleWorker(project, role);
       if (countActiveSlots(roleWorker) > 0) {
-        // Architect is busy — issue created in queue, heartbeat will pick it up when free
-        // Find any active slot's issueId for the message
+        // Strategist is busy — issue created in queue, heartbeat will pick it up when free
         const activeIssueId = Object.values(roleWorker.levels)
           .flat()
           .find((s) => s.active)?.issueId;
@@ -157,13 +156,13 @@ Example:
           research: {
             level,
             status: "queued",
-            reason: `${role.toUpperCase()} already active on #${activeIssueId}. Research ticket queued — architect will pick it up when current work completes.`,
+            reason: `${role.toUpperCase()} already active on #${activeIssueId}. Research ticket queued — strategist will pick it up when current work completes.`,
           },
-          announcement: `\u{1f4d0} Created research ticket #${issue.iid}: ${title} (architect busy — queued)\n\u{1f517} [Issue #${issue.iid}](${issue.web_url})`,
+          announcement: `\u{1f4d0} Created research ticket #${issue.iid}: ${title} (strategist busy — queued)\n\u{1f517} [Issue #${issue.iid}](${issue.web_url})`,
         });
       }
 
-      // Dispatch architect via standard dispatchTask — same pipeline as every other role.
+      // Dispatch strategist via standard dispatchTask — same pipeline as every other role.
       // fromLabel: "To Research" (queue), toLabel: "Researching" (active)
       const toLabel = getActiveLabel(resolvedConfig.workflow, role);
       const dr = await dispatchTask({

--- a/lib/tools/tasks/task-edit-body.ts
+++ b/lib/tools/tasks/task-edit-body.ts
@@ -83,11 +83,12 @@ Examples:
       const resolvedConfig = await loadConfig(workspaceDir, project.name);
       const initialStateLabel = getInitialStateLabel(resolvedConfig.workflow);
 
-      // Collect architect active states as additional editable states
-      const architectActiveStates = Object.values(resolvedConfig.workflow.states)
-        .filter((s) => s.type === "active" && s.role === "architect")
+      // Collect strategist/architect active states as additional editable states
+      // (strategist = MarketClaw research role; architect = DevClaw equivalent — both allowed)
+      const researchActiveStates = Object.values(resolvedConfig.workflow.states)
+        .filter((s) => s.type === "active" && (s.role === "strategist" || s.role === "architect"))
         .map((s) => s.label);
-      const editableStates = [initialStateLabel, ...architectActiveStates];
+      const editableStates = [initialStateLabel, ...researchActiveStates];
 
       // Fetch current issue
       const issue = await provider.getIssue(issueId);

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -1,11 +1,15 @@
 /**
- * work_finish — Complete a task (DEV done, QA pass/fail/refine/blocked, architect done/blocked).
+ * work_finish — Complete a task for any MarketClaw role.
  *
  * Delegates side-effects to pipeline service: label transition, state update,
  * issue close/reopen, notifications, and audit logging.
  *
- * All roles (including architect) use the standard pipeline via executeCompletion.
- * Architect workflow: Researching → Done (done, closes issue), Researching → Refining (blocked).
+ * Role workflows:
+ * - Creator done (content PR created) → To Review; blocked → Refining
+ * - Reviewer approve → To Publish; reject → To Improve; blocked → Refining
+ * - Publisher pass → Published; fail → To Improve; blocked → Refining
+ * - Strategist done → Done (closes issue); blocked → Refining
+ * - Analyst done → Done (closes issue); blocked → Refining
  */
 import { jsonResult } from "openclaw/plugin-sdk";
 import { readFile } from "node:fs/promises";
@@ -179,7 +183,7 @@ export function createWorkFinishTool(ctx: PluginContext) {
   return (toolCtx: ToolContext) => ({
     name: "work_finish",
     label: "Work Finish",
-    description: `Complete a task: Developer done (PR created, goes to review) or blocked. Tester pass/fail/refine/blocked. Reviewer approve/reject/blocked. Architect done/blocked. Handles label transition, state update, issue close/reopen, notifications, and audit logging.`,
+    description: `Complete a task: Creator done (content PR created, goes to review) or blocked. Publisher pass/fail/blocked. Reviewer approve/reject/blocked. Strategist done/blocked. Analyst done/blocked. Handles label transition, state update, issue close/reopen, notifications, and audit logging.`,
     parameters: {
       type: "object",
       required: ["channelId", "role", "result"],
@@ -200,7 +204,7 @@ export function createWorkFinishTool(ctx: PluginContext) {
               url: { type: "string", description: "Issue URL" },
             },
           },
-          description: "Tasks created during this work session (architect creates implementation tasks).",
+          description: "Tasks created during this work session (strategist creates content tasks).",
         },
       },
     },


### PR DESCRIPTION
## Summary

Addresses issue #6

The analytics trigger was silently failing because `analyticsTriggerPass` called `provider.listIssuesByLabel(state.label)` which only queries **open** issues (GitHub/GitLab default). When Publisher calls `work_finish(result: "pass")`, the issue is closed with the `Published` label — so it was never found.

## Changes

- **`lib/providers/provider.ts`**: Extended `listIssuesByLabel` signature to accept optional `opts?: { state?: "open" | "closed" | "all" }`
- **`lib/providers/github.ts`**: Passes the `state` to `gh issue list --state` (defaults to `open` for backward compatibility)
- **`lib/providers/gitlab.ts`**: Passes `--closed`/`--all`/`--opened` flags accordingly
- **`lib/services/heartbeat/analytics-trigger.ts`**: Queries with `{ state: "closed" }` since the publisher closes issues on completion

## Testing

1. Build passes ✅ (`npm run build`)
2. TypeScript check clean ✅ (`tsc --noEmit`)